### PR TITLE
Reset page when sorting by a new column

### DIFF
--- a/browser/templates/browser/table.html
+++ b/browser/templates/browser/table.html
@@ -27,7 +27,7 @@
                             {% for column in table.columns %}
                                 <th {{ column.attrs.th.as_html }}>
                                     {% if column.orderable %}
-                                        <a href="{% querystring table.prefixed_order_by_field=column.order_by_alias.next %}">{{ column.header }}</a>
+                                        <a href="{% querystring table.prefixed_order_by_field=column.order_by_alias.next 'search'='' %}">{{ column.header }}</a>
                                     {% else %}
                                         {{ column.header }}
                                     {% endif %}


### PR DESCRIPTION
For instance when on page 2 and you select the "Start" column it will now take you to page 1 of the results sorted by Start time, instead of page 2 like it used to.